### PR TITLE
Fix literal \n in README Codex Plugin heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ claude plugin install dart-flutter@dart-flutter
 ```bash
 claude plugin marketplace list
 ```
-\n### Codex Plugin
+
+### Codex Plugin
 
 Add the Dart and Flutter marketplace for Codex plugins:
 


### PR DESCRIPTION
## Summary
Fixes a rendering bug in `README.md` where the Codex Plugin section heading was prefixed with a literal `\n` instead of an actual newline, causing it to display as plain text rather than a level-3 heading.

## Motivation and Context
Introduced in #177 ("Add Codex plugin"). No existing issues or PRs address this bug.

## What changed
- **`README.md`**: Replaced `\n### Codex Plugin` with a blank line followed by `### Codex Plugin`, matching the formatting of the Claude Code Plugin and Cursor Plugin sections above and below it.

## Testing Instructions
- View `README.md` on GitHub and confirm the "Codex Plugin" heading renders correctly as a level-3 heading.