### PR TITLE
fix: add missing metadata.last_modified to dart-write-documentation skill

### DIFF
--- a/skills/dart-write-documentation/SKILL.md
+++ b/skills/dart-write-documentation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dart-write-documentation
 description: "Rules and formatting guidelines for writing Dart /// API documentation and doc comments. Use when documenting Dart code, writing doc comments for any Dart declaration (libraries, classes, methods, variables, etc.), or when instructed to follow the Effective Dart documentation guidelines."
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Mon, 24 Aug 2026 17:16:53 GMT
 ---
 
 # Writing Dart API Documentation


### PR DESCRIPTION
When `dart-write-documentation` was synced from `dart-lang/skills` in #224, it lacked the `metadata` block with `last_modified` required by `LastModifiedRule` in `tool/generator/test/custom_skill_rules/last_modified_rule.dart`.

This caused `test/lint_skills_test.dart` to fail CI across all platforms on PRs modifying `skills/` (such as #230).

Adding the missing `metadata.last_modified` field fixes CI.